### PR TITLE
Feat add solar flares api

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -5,11 +5,7 @@ import CoronalMassInjection from "./Components/APIs/SpaceWeather/CoronalMassInje
 import SolarFlares from "./Components/APIs/SpaceWeather/SolarFlares";
 
 function App() {
-  return (
-    <div className='App'>
-      <SolarFlares />
-    </div>
-  );
+  return <div className='App'></div>;
 }
 
 export default App;

--- a/src/App.js
+++ b/src/App.js
@@ -2,12 +2,12 @@ import React from "react";
 import "./App.css";
 import SingUp from "./Components/Auth/SingUp";
 import CoronalMassInjection from "./Components/APIs/SpaceWeather/CoronalMassInjection";
+import SolarFlares from "./Components/APIs/SpaceWeather/SolarFlares";
 
 function App() {
   return (
     <div className='App'>
-      <SingUp />
-      <CoronalMassInjection />
+      <SolarFlares />
     </div>
   );
 }

--- a/src/Components/APIs/SpaceWeather/SolarFlares.js
+++ b/src/Components/APIs/SpaceWeather/SolarFlares.js
@@ -1,8 +1,11 @@
 import React, { useEffect } from "react";
-import { useDispatch } from "react-redux";
+import { useDispatch, dispatch, useSelector } from "react-redux";
+import { getFLR } from "../../../Store/weather/SolarFlare/actions";
+import { selectSolarFlare } from "../../../Store/weather/SolarFlare/selector";
 
 export default function SolarFlares() {
   const dispatch = useDispatch();
+  const solarFlare = useSelector(selectSolarFlare);
 
   // FLR = Solar Flare - type of space weather
   useEffect(() => {

--- a/src/Components/APIs/SpaceWeather/SolarFlares.js
+++ b/src/Components/APIs/SpaceWeather/SolarFlares.js
@@ -7,14 +7,34 @@ export default function SolarFlares() {
   const dispatch = useDispatch();
   const solarFlare = useSelector(selectSolarFlare);
 
+  function renderSolarFlare() {
+    if (!solarFlare) {
+      return <p>No Solar Flares were sighted in the last 30 days</p>;
+    }
+    {
+      return (
+        <>
+          <p>
+            A class {solarFlare.classType} solar flare has been recorded in our
+            solar system.
+          </p>
+          <p>
+            Its begintime was: {solarFlare.beginTime} and it peaked at:{" "}
+            {solarFlare.peakTime}
+          </p>
+        </>
+      );
+    }
+  }
+
   // FLR = Solar Flare - type of space weather
   useEffect(() => {
     dispatch(getFLR());
-  });
-
+  }, []);
   return (
     <div>
       <h3>Solar Flares</h3>
+      {renderSolarFlare()}
     </div>
   );
 }

--- a/src/Components/APIs/SpaceWeather/SolarFlares.js
+++ b/src/Components/APIs/SpaceWeather/SolarFlares.js
@@ -1,0 +1,17 @@
+import React, { useEffect } from "react";
+import { useDispatch } from "react-redux";
+
+export default function SolarFlares() {
+  const dispatch = useDispatch();
+
+  // FLR = Solar Flare - type of space weather
+  useEffect(() => {
+    dispatch(getFLR());
+  });
+
+  return (
+    <div>
+      <h3>Solar Flares</h3>
+    </div>
+  );
+}

--- a/src/Config/constants.js
+++ b/src/Config/constants.js
@@ -1,4 +1,8 @@
 export const URL = process.env.URL || "http://localhost:4000";
-export const NASA_CME_URL = `https://api.nasa.gov/DONKI/CME?startDate=yyyy-MM-dd&endDate=yyyy-MM-dd`;
+
 export const DEFAULT_MESSAGE_TIMEOUT = 3000;
 export const NASAK = `Vm46Sua8HKQqccljF8wS2RdaxtfGeHyBLf8KHBzT`;
+
+//NASA API URL collection
+export const NASA_CME_URL = `https://api.nasa.gov/DONKI/CME?startDate=yyyy-MM-dd&endDate=yyyy-MM-dd`;
+export const NASA_FLR_URL = `https://api.nasa.gov/DONKI/FLR?startDate=yyyy-MM-dd&endDate=yyyy-MM-dd&api_key=`;

--- a/src/Config/constants.js
+++ b/src/Config/constants.js
@@ -5,4 +5,4 @@ export const NASAK = `Vm46Sua8HKQqccljF8wS2RdaxtfGeHyBLf8KHBzT`;
 
 //NASA API URL collection
 export const NASA_CME_URL = `https://api.nasa.gov/DONKI/CME?startDate=yyyy-MM-dd&endDate=yyyy-MM-dd`;
-export const NASA_FLR_URL = `https://api.nasa.gov/DONKI/FLR?startDate=yyyy-MM-dd&endDate=yyyy-MM-dd&api_key=`;
+export const NASA_FLR_URL = `https://api.nasa.gov/DONKI/FLR?startDate=yyyy-MM-dd&endDate=yyyy-MM-dd`;

--- a/src/Store/rootReducer.js
+++ b/src/Store/rootReducer.js
@@ -1,8 +1,10 @@
 import { combineReducers } from "redux";
-import user from "./user/reducer"
-import coronalMassInjection from "./weather/CoronalMassInjection/reducer"
+import user from "./user/reducer";
+import coronalMassInjection from "./weather/CoronalMassInjection/reducer";
+import solarFlare from "./weather/SolarFlare/reducer";
 
 export default combineReducers({
-    user,
-    coronalMassInjection
-})
+  user,
+  coronalMassInjection,
+  solarFlare,
+});

--- a/src/Store/weather/SolarFlare/actions.js
+++ b/src/Store/weather/SolarFlare/actions.js
@@ -1,0 +1,8 @@
+import axios from "axios";
+import NASAK from "../../../Config/constants";
+
+export function getFLR() {
+  return async (dispatch, getState) => {
+    console.log("works?");
+  };
+}

--- a/src/Store/weather/SolarFlare/actions.js
+++ b/src/Store/weather/SolarFlare/actions.js
@@ -1,8 +1,23 @@
 import axios from "axios";
-import NASAK from "../../../Config/constants";
+import { NASAK, NASA_FLR_URL } from "../../../Config/constants";
+
+export const FLR_FETCH_SUCCESS = "FLR_FETCH_SUCCESS";
+
+export function fetchedFLRsuccess(data) {
+  return {
+    type: FLR_FETCH_SUCCESS,
+    payload: data,
+  };
+}
 
 export function getFLR() {
   return async (dispatch, getState) => {
-    console.log("works?");
+    try {
+      const res = await axios.get(`${NASA_FLR_URL}&api_key=${NASAK}`);
+      //   console.log("Whats my response?", res.data);
+      dispatch(fetchedFLRsuccess(res.data[0]));
+    } catch (e) {
+      console.log("ERROR MESSAGE:", e);
+    }
   };
 }

--- a/src/Store/weather/SolarFlare/reducer.js
+++ b/src/Store/weather/SolarFlare/reducer.js
@@ -1,9 +1,14 @@
-const initialState = {};
+import { FLR_FETCH_SUCCESS } from "./actions";
+const initialState = {
+  classType: null,
+  beginTime: null,
+  peakTime: null,
+};
 
 export default (state = initialState, { type, payload }) => {
   switch (type) {
-    // case typeName:
-    //     return { ...state, ...payload }
+    case FLR_FETCH_SUCCESS:
+      return { ...state, ...payload };
 
     default:
       return state;

--- a/src/Store/weather/SolarFlare/reducer.js
+++ b/src/Store/weather/SolarFlare/reducer.js
@@ -1,0 +1,11 @@
+const initialState = {};
+
+export default (state = initialState, { type, payload }) => {
+  switch (type) {
+    // case typeName:
+    //     return { ...state, ...payload }
+
+    default:
+      return state;
+  }
+};

--- a/src/Store/weather/SolarFlare/selector.js
+++ b/src/Store/weather/SolarFlare/selector.js
@@ -1,0 +1,1 @@
+export const selectSolarFlare = (state) => state.SolarFlare;


### PR DESCRIPTION
## what this pullrequest does: 
- this request creates a solarFlare report component.
- it adds the API-url to constants in config
- it dispatches a API call to the NASA API via redux thunk call
- it stores the response in a Solar flare slice inside the redux Store.
- it renders some example data on the component
- it adds a ternary operator that shows a message when no data has been uploaded to the API in the last 30 days

The Solar Flare report works on a 30 day default rate - it shows 0 data when no solar flare has been sighted in the last 30 days inside our solar system. 

Consider aading a image so people have a visual representation of what these space weather conditions are. 